### PR TITLE
Minor bug fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='xxxswf',
-    version='2.0.0',
+    version='2.0.1',
     description=('xxxswf.py is a Python script for carving, scanning,' +
                  ' compressing, decompressing and analyzing Flash SWF files.'),
     long_description=long_description,

--- a/xxxswf/xxxswf.py
+++ b/xxxswf/xxxswf.py
@@ -2,9 +2,9 @@
 Name:
     xxxswf.py
 Version:
-    2.0.0
+    2.0.1
 Date:
-    2017/02/02
+    2020/07/02
 Author:
     alexander<dot>hanel<at>gmail<dot>com
 
@@ -285,7 +285,7 @@ class xxxswf:
                 return None
             # set index to version, skipping over the header
             stream.seek(addr + 3)
-            return "FWS" + stream.read(5) + uncompress_data[:size - 8]
+            return b"FWS" + stream.read(5) + uncompress_data[:size - 8]
         elif header == b"ZWS":
             if self.cmd_run:
                 print("- ZWS Header")
@@ -375,7 +375,7 @@ class xxxswf:
         """compress a SWF with LZMA"""
         if isinstance(swf, bytes):
             swf = BytesIO(swf)
-        if not self.lzma_install:
+        if not HAVE_LZMA:
             if self.show_errors:
                 print("\t[ERROR] pylzma module not installed - aborting validation/decompression")
             return None


### PR DESCRIPTION
When using the '-z' feature in python3, xxxswf incorrectly errors out with an error at line 378 'xxxswf' object has no attribute 'lzma_install'. This was a remnant from the original version. Replaced the validation with 'if not HAVE_LZMA'.

Also, when examining a single swf file, python3 produces an error at line 288: 'return "FWS" + stream.read(5) + uncompress_data[:size - 8] - TypeError: must be str, not bytes.

Adding the byte marker to the return statement fixes this output error.

Updated the minor version and modification date to reflect these changes.